### PR TITLE
Fix default noise level for `NoiseAugmentation`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplainableAI"
 uuid = "4f1bc3e1-d60d-4ed0-9367-9bdff9846d3b"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.9.1-DEV"
+version = "0.10.0-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplainableAI"
 uuid = "4f1bc3e1-d60d-4ed0-9367-9bdff9846d3b"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.10.0-DEV"
+version = "0.9.1-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplainableAI"
 uuid = "4f1bc3e1-d60d-4ed0-9367-9bdff9846d3b"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.9.0"
+version = "0.10.0-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -75,8 +75,8 @@ function call_analyzer(
 end
 
 """
-    SmoothGrad(analyzer, [n=50, std=0.1, rng=GLOBAL_RNG])
-    SmoothGrad(analyzer, [n=50, distribution=Normal(0, σ²=0.01), rng=GLOBAL_RNG])
+    SmoothGrad(analyzer, [n=50, std=1.0, rng=GLOBAL_RNG])
+    SmoothGrad(analyzer, [n=50, distribution=Normal(0, 1), rng=GLOBAL_RNG])
 
 Analyze model by calculating a smoothed sensitivity map.
 This is done by averaging sensitivity maps of a `Gradient` analyzer over random samples

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -75,8 +75,8 @@ function call_analyzer(
 end
 
 """
-    SmoothGrad(analyzer, [n=50, std=1.0, rng=GLOBAL_RNG])
-    SmoothGrad(analyzer, [n=50, distribution=Normal(0, 1), rng=GLOBAL_RNG])
+    SmoothGrad(analyzer, [n=50, std=1.0f0, rng=GLOBAL_RNG])
+    SmoothGrad(analyzer, [n=50, distribution=Normal(0.0f0, 1.0f0), rng=GLOBAL_RNG])
 
 Analyze model by calculating a smoothed sensitivity map.
 This is done by averaging sensitivity maps of a `Gradient` analyzer over random samples

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -91,7 +91,7 @@ A wrapper around analyzers that augments the input with `n` samples of additive 
 This input augmentation is then averaged to return an `Explanation`.
 
 Defaults to the normal distribution `Normal(0, std^2)` with `std=1`.
-For optimal results, $REF_SMILKOV_SMOOTHGRAD recommends setting `std` between 10% and 20% of the input range of every sample,
+For optimal results, $REF_SMILKOV_SMOOTHGRAD recommends setting `std` between 10% and 20% of the input range of each sample,
 e.g. `std = 0.1 * (maximum(input) - minimum(input))`.
 
 ## Keyword arguments

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -90,7 +90,7 @@ end
 A wrapper around analyzers that augments the input with `n` samples of additive noise sampled from a scalar `distribution`.
 This input augmentation is then averaged to return an `Explanation`.
 
-Defaults to the normal distribution `Normal(0, std^2)` with `std=1`.
+Defaults to the normal distribution `Normal(0, std^2)` with `std=1.0f0`.
 For optimal results, $REF_SMILKOV_SMOOTHGRAD recommends setting `std` between 10% and 20% of the input range of each sample,
 e.g. `std = 0.1 * (maximum(input) - minimum(input))`.
 

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -83,11 +83,20 @@ function augment_indices(inds::Vector{CartesianIndex{N}}, n) where {N}
 end
 
 """
-    NoiseAugmentation(analyzer, n, [std=1, rng=GLOBAL_RNG])
-    NoiseAugmentation(analyzer, n, distribution, [rng=GLOBAL_RNG])
+    NoiseAugmentation(analyzer, n)
+    NoiseAugmentation(analyzer, n, std::Real)
+    NoiseAugmentation(analyzer, n, distribution::Sampleable)
 
-A wrapper around analyzers that augments the input with `n` samples of additive noise sampled from `distribution`.
+A wrapper around analyzers that augments the input with `n` samples of additive noise sampled from a scalar `distribution`.
 This input augmentation is then averaged to return an `Explanation`.
+
+Defaults to the normal distribution `Normal(0, std^2)` with `std=1`.
+For optimal results, $REF_SMILKOV_SMOOTHGRAD recommends setting `std` between 10% and 20% of the input range of every sample,
+e.g. `std = 0.1 * (maximum(input) - minimum(input))`.
+
+## Keyword arguments
+- `rng::AbstractRNG`: Specify the random number generator that is used to sample noise from the `distribution`. 
+  Defaults to `GLOBAL_RNG`. 
 """
 struct NoiseAugmentation{A<:AbstractXAIMethod,D<:Sampleable,R<:AbstractRNG} <:
        AbstractXAIMethod
@@ -96,11 +105,11 @@ struct NoiseAugmentation{A<:AbstractXAIMethod,D<:Sampleable,R<:AbstractRNG} <:
     distribution::D
     rng::R
 end
-function NoiseAugmentation(analyzer, n, distr::Sampleable, rng=GLOBAL_RNG)
-    return NoiseAugmentation(analyzer, n, distr::Sampleable, rng)
+function NoiseAugmentation(analyzer, n, distribution::Sampleable, rng=GLOBAL_RNG)
+    return NoiseAugmentation(analyzer, n, distribution::Sampleable, rng)
 end
-function NoiseAugmentation(analyzer, n, σ::Real=0.1f0, args...)
-    return NoiseAugmentation(analyzer, n, Normal(0.0f0, Float32(σ)^2), args...)
+function NoiseAugmentation(analyzer, n, std::T=1.0f0, rng=GLOBAL_RNG) where {T<:Real}
+    return NoiseAugmentation(analyzer, n, Normal(zero(T), std^2), rng)
 end
 
 function call_analyzer(input, aug::NoiseAugmentation, ns::AbstractOutputSelector; kwargs...)

--- a/src/input_augmentation.jl
+++ b/src/input_augmentation.jl
@@ -56,7 +56,7 @@ end
 """
     augment_indices(indices, n)
 
-Strip batch indices and return inidices for batch augmented by n samples.
+Strip batch indices and return indices for batch augmented by n samples.
 
 ## Example
 ```julia-repl


### PR DESCRIPTION
The previous `std` was `0.1` instead of the documented `1.0`.
A value of one is more in line with the recommendation from the SmoothGrad paper, which has been added to the docstring:

```md
For optimal results, $REF_SMILKOV_SMOOTHGRAD recommends setting `std` between 10% and 20% of the input range of every sample,
e.g. `std = 0.1 * (maximum(input) - minimum(input))`.
```